### PR TITLE
Added `data_for_univariate` argument to: cox2.display, geeglm.display, lmer.display.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jstable
 Title: Create Tables from Different Types of Regression
 Version: 1.3.14
-Date: 2025-06-30
+Date: 2025-07-18
 Authors@R: c(person("Jinseob", "Kim", email = "jinseob2kim@gmail.com", role = c("aut", "cre"),  comment = c(ORCID = "0000-0002-9403-605X")),
              person("Zarathu", role = c("cph", "fnd")),
              person("Yoonkyoung","Jeon", role = c("aut")),
@@ -10,6 +10,7 @@ Authors@R: c(person("Jinseob", "Kim", email = "jinseob2kim@gmail.com", role = c(
              person("Hyungwoo", "Jo", role = c("aut")),
              person("Sungho", "Choi", role = c("aut")),
              person("Jaewoong", "Heo", role = c("aut"))
+             person("Mingu", "Jee", role = c("aut"))
              )
 Description: Create regression tables from generalized linear model(GLM), generalized estimating equation(GEE), generalized linear mixed-effects model(GLMM), Cox proportional hazards model, survey-weighted generalized linear model(svyglm) and survey-weighted Cox model results for publication.
 Depends: R (>= 3.4.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# jstable 1.3.15
+* Update: Add `data_for_univariate` in `cox2.display`, `geeglm.display`, `lmer.display`, crude p-values in univariate tables are now computed directly from the raw data passed via `data_for_univariate`.
+
 # jstable 1.3.14
 * Fix: error in `cox2.display` when all status 0
 * Update: Add testcode of `cox2.display` when all status 0 (isList, column&row name diff check)

--- a/R/cox2.R
+++ b/R/cox2.R
@@ -18,12 +18,13 @@
 #' @importFrom survival coxph cluster frailty
 #' @importFrom stats formula update AIC
 #'
-cox2.display <- function(cox.obj.withmodel, dec = 2, msm = NULL, pcut.univariate = NULL) {
+cox2.display <- function(cox.obj.withmodel, dec = 2, msm = NULL, pcut.univariate = NULL, data_for_univariate = NULL) {
   model <- cox.obj.withmodel
   if (!any(class(model) == "coxph")) {
     stop("Model not from Cox model")
   }
   xf <- attr(model$terms, "term.labels") # Independent vars
+  xf_keep <- xf
   xf.old <- xf
   xc <- NULL
   xc.vn <- NULL
@@ -49,15 +50,15 @@ cox2.display <- function(cox.obj.withmodel, dec = 2, msm = NULL, pcut.univariate
     xc.vn <- xc
     # xc.vn <- strsplit(strsplit(xc, "cluster\\(")[[1]][2], "\\)")[[1]][1]
   }
-
-# handle no event case
-if (model$nevent == 0) {
+  
+  # handle no event case
+  if (model$nevent == 0) {
     # metrics
     no.obs <- model$n
     no.event <- model$nevent
     aic <- NA # no event
     c_index <- "NA (NA)" # no event
-
+    
     # vars
     var_names <- xf  # variable names
     if (length(var_names) == 0) var_names <- "No variables"
@@ -68,17 +69,17 @@ if (model$nevent == 0) {
     }
     fix.all.unlist <- matrix(NA, nrow = length(var_names), ncol = length(col_names), 
                              dimnames = list(var_names, col_names))
-
+    
     # metric table
     metric.mat <- cbind(c(NA, no.obs, no.event, aic, c_index), matrix(NA, 5, max(1, ncol(fix.all.unlist) - 1)))
     rownames(metric.mat) <- c(NA, "No. of observations", "No. of events", "AIC", "C-Index")
-
+    
     # caption
     surv.string <- as.character(attr(model$terms, "variables")[[2]])
     time.var.name <- paste(sapply(2:(length(surv.string) - 1), function(i) paste(surv.string[i])), collapse = ", ")
     status.var.name <- surv.string[length(surv.string)]
     intro <- paste("Cox model on time ('", time.var.name, "') to event ('", status.var.name, "')", sep = "")
-
+    
     # type info
     cvname_for_caption <- if (is.null(xc.vn)) "N/A" else xc.vn
     if (mtype == "cluster") {
@@ -86,7 +87,7 @@ if (model$nevent == 0) {
     } else if (mtype == "frailty") {
       intro <- paste("Frailty", intro, "- Group", cvname_for_caption)
     }
-
+    
     # fixed effect
     var_names <- xf
     if (length(var_names) == 0) var_names <- "No variables"
@@ -97,7 +98,7 @@ if (model$nevent == 0) {
     }
     fix.all.unlist <- matrix(NA, nrow = length(var_names), ncol = length(col_names), 
                              dimnames = list(var_names, col_names))
-
+    
     # random effect
     ranef.mat <- NULL
     if (mtype == "cluster" || mtype == "frailty") {
@@ -108,7 +109,7 @@ if (model$nevent == 0) {
         rownames(ranef.mat) <- c("frailty", xc.vn)
       }
     }
-
+    
     # return
     if (is.null(ranef.mat)) {
       return(list(table = fix.all.unlist, metric = metric.mat, caption = intro))
@@ -175,34 +176,75 @@ if (model$nevent == 0) {
     }
     
     if (!is.null(msm)) {
-      baseformula <- stats::formula(paste(c(". ~ .", xf), collapse = " - "))
-      unis <- lapply(xf, function(x) {
-        newfit <- update(model, stats::formula(paste(c(baseformula, x), collapse = "+")))
-        uni.res <- data.frame(summary(newfit)$coefficients)
-        if (grepl(":", x)) {
-          uni.res <- uni.res[rownames(uni.res) %in% rownames(summary(model)$coefficients), ]
-        } else {
-          uni.res <- uni.res[grep(x, rownames(uni.res)), ]
-        }
-        # uni.res <- uni.res[c(2:nrow(uni.res), 1), ]
-        # uni.res <- data.frame(summary(coxph(as.formula(paste("mdata[, 1]", "~", x, formula.ranef, sep="")), data = mdata))$coefficients)
-        names(uni.res)[ncol(uni.res)] <- "p"
-        uni.res2 <- NULL
-        if (mtype == "normal") {
-          uni.res2 <- uni.res[, c(1, 3, 4, 5)]
-          if (length(grep("robust.se", names(uni.res))) > 0) {
-            uni.res2 <- uni.res[, c(1, 4, 5, 6)]
+      if (is.null(data_for_univariate)) {
+        baseformula <- stats::formula(paste(c(". ~ .", xf), collapse = " - "))
+        unis <- lapply(xf, function(x) {
+          newfit <- update(model, stats::formula(paste(c(baseformula, x), collapse = "+")))
+          uni.res <- data.frame(summary(newfit)$coefficients)
+          if (grepl(":", x)) {
+            uni.res <- uni.res[rownames(uni.res) %in% rownames(summary(model)$coefficients), ]
+          } else {
+            uni.res <- uni.res[grep(x, rownames(uni.res)), ]
           }
-        } else if (mtype == "cluster") {
-          uni.res2 <- uni.res[, c(1, 4, 5, 6)]
-        } else {
-          uni.res2 <- uni.res[, c(1, 3, 4, 6)]
-        }
-        return(uni.res2)
-      })
-      rn.uni <- lapply(unis, rownames)
-      unis2 <- Reduce(rbind, unis)
-      uni.res <- unis2
+          # uni.res <- uni.res[c(2:nrow(uni.res), 1), ]
+          # uni.res <- data.frame(summary(coxph(as.formula(paste("mdata[, 1]", "~", x, formula.ranef, sep="")), data = mdata))$coefficients)
+          names(uni.res)[ncol(uni.res)] <- "p"
+          uni.res2 <- NULL
+          if (mtype == "normal") {
+            uni.res2 <- uni.res[, c(1, 3, 4, 5)]
+            if (length(grep("robust.se", names(uni.res))) > 0) {
+              uni.res2 <- uni.res[, c(1, 4, 5, 6)]
+            }
+          } else if (mtype == "cluster") {
+            uni.res2 <- uni.res[, c(1, 4, 5, 6)]
+          } else {
+            uni.res2 <- uni.res[, c(1, 3, 4, 6)]
+          }
+          return(uni.res2)
+        })
+        keep <- !vapply(unis, is.null, logical(1))
+        unis        <- unis[keep]
+        xf_keep     <- xf[keep]
+        if (length(unis) == 0) stop("All univariate fits failed")
+        rn.uni <- lapply(unis, rownames)
+        unis2 <- Reduce(rbind, unis)
+        uni.res <- unis2
+        colnames(uni.res) <- c("coef","se","z","p")
+        } else {unis <- lapply(xf, function(x) {
+          lhs      <- paste(deparse(model$call$formula[[2]]), collapse = "")
+          randTerm <- if (mtype=="cluster") {
+            paste0("+cluster(", xc.vn, ")")
+          } else if (mtype=="frailty") {
+            paste0("+frailty(", xc.vn, ")")
+          } else ""
+          uni_fmla <- as.formula(paste0(lhs, " ~ ", x, randTerm))
+
+          needed   <- all.vars(model$call$formula[[2]])
+          if (randTerm!="") needed <- c(needed, xc.vn)
+          df_uni   <- data_for_univariate[complete.cases(data_for_univariate[, c(needed, x)]), ]
+          
+          fit_uni  <- survival::coxph(uni_fmla,
+                                      data      = df_uni,
+                                      model     = TRUE,
+                                      na.action = na.omit)
+          
+          cm       <- summary(fit_uni)$coefficients
+          cols     <- c(1,
+                        which(colnames(cm) %in% c("se(coef)","robust.se")),
+                        which(colnames(cm)=="z"),
+                        which(colnames(cm) %in% c("Pr(>|z|)","Pr(>|t|)")))[1:4]
+          return(cm[, cols, drop=FALSE])
+        })
+        keep <- !vapply(unis, is.null, logical(1))
+        unis        <- unis[keep]
+        xf_keep     <- xf[keep]
+        if (length(unis) == 0) stop("All univariate fits failed")
+        rn.uni <- lapply(unis, rownames)
+        unis2 <- Reduce(rbind, unis)
+        uni.res <- unis2
+        colnames(uni.res) <- c("coef","se","z","p")
+        
+      }
       
       if (is.null(pcut.univariate)){
         mul.res <- data.frame(coefNA(model))
@@ -265,43 +307,91 @@ if (model$nevent == 0) {
       
       uni.res <- uni.res[rownames(uni.res) %in% rownames(mul.res), ]
       colnames(mul.res)[ncol(mul.res)] <- "p"
-      fix.all <- cbind(coxExp(uni.res, dec = dec), coxExp(mul.res[rownames(uni.res), names(uni.res)], dec = dec))
+      mul_for_exp <- mul.res[rownames(uni.res), c(1, 2, ncol(mul.res)), drop = FALSE]
+      colnames(mul_for_exp)[3] <- "p"  # 세 번째 열이 p가 되게 만듭니다
+      fix.all <- cbind(
+        coxExp(uni.res,    dec = dec),
+        coxExp(mul_for_exp, dec = dec)
+      )      
       colnames(fix.all) <- c("crude HR(95%CI)", "crude P value", "adj. HR(95%CI)", "adj. P value")
       rownames(fix.all) <- rownames(uni.res)
     } else {
-      basemodel <- update(model, stats::formula(paste(c(". ~ .", xf), collapse = " - ")), data = mdata2)
-      
-      unis <- lapply(xf, function(x) {
-        newfit <- update(basemodel, stats::formula(paste0(". ~ . +", x)), data = mdata2)
-        uni.res <- data.frame(summary(newfit)$coefficients)
-        if (grepl(":", x)) {
-          uni.res <- uni.res[rownames(uni.res) %in% rownames(summary(model)$coefficients), ]
-        } else {
-          uni.res <- uni.res[grep(x, rownames(uni.res)), ]
-        }
-        # uni.res <- uni.res[c(2:nrow(uni.res), 1), ]
-        # uni.res <- data.frame(summary(coxph(as.formula(paste("mdata[, 1]", "~", x, formula.ranef, sep="")), data = mdata))$coefficients)
-        names(uni.res)[ncol(uni.res)] <- "p"
-        # if ("robust.se" %in% names(uni.res)) {
-        #   uni.res$robust.se <- NULL
-        # }
+      if (is.null(data_for_univariate)) {
+        basemodel <- update(model, stats::formula(paste(c(". ~ .", xf), collapse = " - ")), data = mdata2)
         
-        uni.res2 <- NULL
-        if (mtype == "normal") {
-          uni.res2 <- uni.res[, c(1, 3, 4, 5)]
-          if (length(grep("robust.se", names(uni.res))) > 0) {
-            uni.res2 <- uni.res[, c(1, 4, 5, 6)]
+        unis <- lapply(xf, function(x) {
+          newfit <- update(basemodel, stats::formula(paste0(". ~ . +", x)), data = mdata2)
+          uni.res <- data.frame(summary(newfit)$coefficients)
+          if (grepl(":", x)) {
+            uni.res <- uni.res[rownames(uni.res) %in% rownames(summary(model)$coefficients), ]
+          } else {
+            uni.res <- uni.res[grep(x, rownames(uni.res)), ]
           }
-        } else if (mtype == "cluster") {
-          uni.res2 <- uni.res[, c(1, 4, 5, 6)]
-        } else {
-          uni.res2 <- uni.res[, c(1, 3, 4, 6)]
-        }
-        return(uni.res2)
+          # uni.res <- uni.res[c(2:nrow(uni.res), 1), ]
+          # uni.res <- data.frame(summary(coxph(as.formula(paste("mdata[, 1]", "~", x, formula.ranef, sep="")), data = mdata))$coefficients)
+          names(uni.res)[ncol(uni.res)] <- "p"
+          # if ("robust.se" %in% names(uni.res)) {
+          #   uni.res$robust.se <- NULL
+          # }
+          
+          uni.res2 <- NULL
+          if (mtype == "normal") {
+            uni.res2 <- uni.res[, c(1, 3, 4, 5)]
+            if (length(grep("robust.se", names(uni.res))) > 0) {
+              uni.res2 <- uni.res[, c(1, 4, 5, 6)]
+            }
+          } else if (mtype == "cluster") {
+            uni.res2 <- uni.res[, c(1, 4, 5, 6)]
+          } else {
+            uni.res2 <- uni.res[, c(1, 3, 4, 6)]
+          }
+          return(uni.res2)
+        })
+        keep <- !vapply(unis, is.null, logical(1))
+        unis        <- unis[keep]
+        xf_keep     <- xf[keep]
+        if (length(unis) == 0) stop("All univariate fits failed")
+        rn.uni <- lapply(unis, rownames)
+        unis2 <- Reduce(rbind, unis)
+        uni.res <- unis2
+        colnames(uni.res) <- c("coef","se","z","p")
+      } else {
+        unis <- lapply(xf, function(x) {
+        lhs      <- paste(deparse(model$call$formula[[2]]), collapse = "")
+        randTerm <- if (mtype=="cluster") {
+          paste0("+cluster(", xc.vn, ")")
+        } else if (mtype=="frailty") {
+          paste0("+frailty(", xc.vn, ")")
+        } else ""
+        uni_fmla <- as.formula(paste0(lhs, " ~ ", x, randTerm))
+        
+        needed   <- all.vars(model$call$formula[[2]])
+        if (randTerm!="") needed <- c(needed, xc.vn)
+        df_uni   <- data_for_univariate[complete.cases(data_for_univariate[, c(needed, x)]), ]
+        
+        fit_uni  <- survival::coxph(uni_fmla,
+                                    data      = df_uni,
+                                    model     = TRUE,
+                                    na.action = na.omit)
+        
+        cm       <- summary(fit_uni)$coefficients
+        cols     <- c(1,
+                      which(colnames(cm) %in% c("se(coef)","robust.se")),
+                      which(colnames(cm)=="z"),
+                      which(colnames(cm) %in% c("Pr(>|z|)","Pr(>|t|)")))[1:4]
+        return(cm[, cols, drop=FALSE])
       })
+      keep <- !vapply(unis, is.null, logical(1))
+      unis        <- unis[keep]
+      xf_keep     <- xf[keep]
+      if (length(unis) == 0) stop("All univariate fits failed")
       rn.uni <- lapply(unis, rownames)
       unis2 <- Reduce(rbind, unis)
       uni.res <- unis2
+      colnames(uni.res) <- c("coef","se","z","p")
+      }
+      
+      
       if(is.null(pcut.univariate)){
         mul.res <- data.frame(coefNA(model))
       }else{
@@ -364,13 +454,18 @@ if (model$nevent == 0) {
       
       uni.res <- uni.res[rownames(uni.res) %in% rownames(mul.res), ]
       colnames(mul.res)[ncol(mul.res)] <- "p"
-      fix.all <- cbind(coxExp(uni.res, dec = dec), coxExp(mul.res[rownames(uni.res), names(uni.res)], dec = dec))
+      mul_for_exp <- mul.res[rownames(uni.res), c(1, 2, ncol(mul.res)), drop = FALSE]
+      colnames(mul_for_exp)[3] <- "p"  # 세 번째 열이 p가 되게 만듭니다
+      fix.all <- cbind(
+        coxExp(uni.res,    dec = dec),
+        coxExp(mul_for_exp, dec = dec)
+      )
       colnames(fix.all) <- c("crude HR(95%CI)", "crude P value", "adj. HR(95%CI)", "adj. P value")
       rownames(fix.all) <- rownames(uni.res)
     }
   }
   ## rownames
-  fix.all.list <- lapply(1:length(xf), function(x) {
+  fix.all.list <- lapply(seq_along(xf_keep), function(x) {
     fix.all[rownames(fix.all) %in% rn.uni[[x]], ]
   })
   varnum.mfac <- which(lapply(fix.all.list, length) > ncol(fix.all))
@@ -379,7 +474,7 @@ if (model$nevent == 0) {
   })
   fix.all.unlist <- Reduce(rbind, fix.all.list)
   
-  rn.list <- lapply(1:length(xf), function(x) {
+  rn.list <- lapply(seq_along(xf_keep), function(x) {
     rownames(fix.all)[rownames(fix.all) %in% rn.uni[[x]]]
   })
   varnum.2fac <- which(lapply(xf, function(x) {


### PR DESCRIPTION
Added `data_for_univariate` argument to: cox2.display, geeglm.display, lmer.display.

Crude p-values in univariate tables are now computed directly from the raw data passed via data_for_univariate.