### PR TITLE
fix: update min version for coxme to resolve test fail

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Depends: R (>= 3.4.0)
 License: Apache License 2.0 
 Encoding: UTF-8
 RoxygenNote: 7.3.2
-Imports: geepack, lme4, stats, data.table, labelled, tableone, coxme, survival (>= 3.0.0), survey, methods, dplyr, purrr, magrittr, tibble,  rlang, car, lmerTest, nortest
+Imports: geepack, lme4, stats, data.table, labelled, tableone, coxme (>= 2.2-22), survival (>= 3.0.0), survey, methods, dplyr, purrr, magrittr, tibble,  rlang, car, lmerTest, nortest
 URL: https://github.com/jinseob2kim/jstable, https://jinseob2kim.github.io/jstable/
 BugReports: https://github.com/jinseob2kim/jstable/issues
 Suggests: 


### PR DESCRIPTION
일부 환경에서 test fail 방지하기 위해 coxme 패키지 최소버전 업데이트